### PR TITLE
Add support for custom query matchers in expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ describe 'MyCode' do
       expect { subject.make_one_query }.to make_database_queries(manipulative: true)
     end
   end
+
+  context 'when we only care about queries matching a certain pattern' do
+    it 'makes a destructive database query' do
+      expect { subject.make_special_queries }.to make_database_queries(matching: 'DELETE * FROM')
+    end
+
+    it 'makes a destructive database query matched with a regexp' do
+      expect { subject.make_special_queries }.to make_database_queries(matching: /DELETE/)
+    end
+  end
 end
 ```
 

--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -47,6 +47,15 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
     if options[:manipulative]
       counter_options[:matches] = [/^\ *(INSERT|UPDATE|DELETE\ FROM)/]
     end
+    if options[:matching]
+      counter_options[:matches] ||= []
+      case options[:matching]
+      when Regexp
+        counter_options[:matches] << options[:matching]
+      when String
+        counter_options[:matches] << Regexp.new(Regexp.escape(options[:matching]))
+      end
+    end
     @counter = DBQueryMatchers::QueryCounter.new(counter_options)
     ActiveSupport::Notifications.subscribed(@counter.to_proc,
                                             'sql.active_record',

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -136,6 +136,46 @@ describe '#make_database_queries' do
         end
       end
     end
+
+    context 'when a `matching` option is specified' do
+      context 'with a string matcher' do
+        context 'and there is a query matching the matcher specified' do
+          subject { Cat.create }
+
+          it 'matches true' do
+            expect { subject }.to make_database_queries(matching: 'INSERT')
+          end
+        end
+
+        context 'and there are no queries matching the matcher specified' do
+          it 'raises an error' do
+            expect do
+              expect { subject }.to make_database_queries(matching: 'INSERT')
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                    /expected queries, but none were made/)
+          end
+        end
+      end
+
+      context 'with a regexp matcher' do
+        context 'and there is a query matching the matcher specified' do
+          subject { Cat.create }
+
+          it 'matches true' do
+            expect { subject }.to make_database_queries(matching: /^\ *INSERT/)
+          end
+        end
+
+        context 'and there are no queries matching the matcher specified' do
+          it 'raises an error' do
+            expect do
+              expect { subject }.to make_database_queries(matching: /^\ *INSERT/)
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                    /expected queries, but none were made/)
+          end
+        end
+      end
+    end
   end
 
   context 'when no queries are made' do


### PR DESCRIPTION
That can be either strings or regular expressions