### PR TITLE
Support passing a range to the count: option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master (unreleased)
+
+- Support passing a range to the count: option, by calling the case
+  equality operator on the argument.
+
 ## 0.3.1
 
 - Add `matching` option that allows you to target certain queries.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ describe 'MyCode' do
     end
   end
 
+  context 'when we expect a possible range of queries' do
+    it 'makes database queries' do
+      expect { subject.make_several_queries }.to make_database_queries(count: 3..5)
+    end
+  end
+
   context 'when we only care about manipulative queries (INSERT, UPDATE, DELETE)' do
     it 'makes a destructive database query' do
       expect { subject.make_one_query }.to make_database_queries(manipulative: true)

--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -61,7 +61,7 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
                                             'sql.active_record',
                                             &block)
     if absolute_count = options[:count]
-      @counter.count == absolute_count
+      absolute_count === @counter.count
     else
       @counter.count > 0
     end

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -58,38 +58,56 @@ describe '#make_database_queries' do
     end
 
     context 'when a `count` option is specified' do
-      context 'and the count matches' do
-        it 'matches true' do
-          expect { subject }.to make_database_queries(count: 1)
+      context 'when the count is a range' do
+        context 'and it matches' do
+          it 'matches true' do
+            expect { subject }.to make_database_queries(count: 1..2)
+          end
+        end
+
+        context 'and it does not match' do
+          it 'raises an error' do
+            expect do
+              expect { subject }.to make_database_queries(count: 2..3)
+            end.to raise_error
+          end
         end
       end
 
-      context 'and the count does not match' do
-        it 'raises an error' do
-          expect do
-            expect { subject }.to make_database_queries(count: 2)
-          end.to raise_error
+      context 'when the count is an integer' do
+        context 'and it matches' do
+          it 'matches true' do
+            expect { subject }.to make_database_queries(count: 1)
+          end
         end
 
-        it 'mentions the expected number of queries' do
-          expect do
-            expect { subject }.to make_database_queries(count: 2)
-          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                             /expected 2 queries/)
-        end
+        context 'and it does not match' do
+          it 'raises an error' do
+            expect do
+              expect { subject }.to make_database_queries(count: 2)
+            end.to raise_error
+          end
 
-        it 'mentions the actual number of queries' do
-          expect do
-            expect { subject }.to make_database_queries(count: 2)
-          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                             /but 1 was made/)
-        end
+          it 'mentions the expected number of queries' do
+            expect do
+              expect { subject }.to make_database_queries(count: 2)
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                               /expected 2 queries/)
+          end
 
-        it 'lists the queries made in the error message' do
-          expect do
-            expect { subject }.to make_database_queries(count: 2)
-          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                             /SELECT.*FROM.*cats/)
+          it 'mentions the actual number of queries' do
+            expect do
+              expect { subject }.to make_database_queries(count: 2)
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                               /but 1 was made/)
+          end
+
+          it 'lists the queries made in the error message' do
+            expect do
+              expect { subject }.to make_database_queries(count: 2)
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                               /SELECT.*FROM.*cats/)
+          end
         end
       end
     end


### PR DESCRIPTION
Via the case equality operator.

Because sometimes test data is non-deterministic, even when we don't
want it to be.

This also makes the count: argument a possible extension point,
because while previously the comparison was controlled by the query
count, which was not under the caller's control, now the comparison
method can be implemented on the argument.