### PR TITLE
Add max parameter to make_database_queries matcher

### DIFF
--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -62,6 +62,8 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
                                             &block)
     if absolute_count = options[:count]
       absolute_count === @counter.count
+    elsif max_count = options[:max]
+      @counter.count <= max_count
     else
       @counter.count > 0
     end
@@ -75,8 +77,8 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
   end
 
   failure_message do |_|
-    if options[:count]
-      expected = pluralize(options[:count], 'query')
+    if count = options[:count] || options[:max]
+      expected = pluralize(count, 'query')
       actual   = pluralize(@counter.count, 'was', 'were')
 
       output   = "expected #{expected}, but #{actual} made"

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -112,6 +112,23 @@ describe '#make_database_queries' do
       end
     end
 
+    context 'when the `max` option is specified' do
+      context 'and it matches' do
+        it 'matches true' do
+          expect { subject }.to make_database_queries(max: 1)
+        end
+      end
+
+      context 'and it does not match' do
+        it 'raises an error' do
+          expect do
+            expect { subject }.to make_database_queries(max: 0)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                             /but 1 was made/)
+        end
+      end
+    end
+
     context 'when a `manipulative` option is as true' do
       context 'and there is a create query' do
         subject { Cat.create }


### PR DESCRIPTION
Count supports this idea using the range operator, but it seems clearer
to be able to set a hard maximum on the total number of queries used.