### PR TITLE
Fix wrong error messages for nested block expectations

### DIFF
--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -42,7 +42,7 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
     "#{count || 0} #{word}"
   end
 
-  match do |block|
+  define_method :matches? do |block|
     counter_options = {}
     if options[:manipulative]
       counter_options[:matches] = [/^\ *(INSERT|UPDATE|DELETE\ FROM)/]

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -216,4 +216,17 @@ describe '#make_database_queries' do
                          /expected queries, but none were made/)
     end
   end
+
+  context 'when some other expectation in the block fails' do
+    subject { 
+      Cat.first
+      raise RSpec::Expectations::ExpectationNotMetError.new('other')
+    }
+
+    it 'reraises the error' do
+      expect do
+        expect { subject }.to make_database_queries(count: 1)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /other/)
+    end
+  end
 end


### PR DESCRIPTION
Fix for https://github.com/brigade/db-query-matchers/issues/11 with learnings from https://github.com/rspec/rspec-expectations/issues/890