### PR TITLE
Support `on_counted_query` callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## master (unreleased)
+- Support a `on_counted_query` configuration option that is a callback for
+  arbitrary code.
+
 ## 0.4.0
 
 - Support passing a range to the count: option, by calling the case

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## master (unreleased)
-- Support a `on_counted_query` configuration option that is a callback for
+- Support a `on_query_counted` configuration option that is a callback for
   arbitrary code.
 
 ## 0.4.0

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ DBQueryMatchers.configure do |config|
 
   # the payload argument is described here:
   # http://edgeguides.rubyonrails.org/active_support_instrumentation.html#sql-active-record
-  config.on_counted_query do |payload|
+  config.on_query_counted do |payload|
     # do something arbitrary with the query
   end
 end

--- a/README.md
+++ b/README.md
@@ -89,5 +89,11 @@ counted in the `make_database_queries` matcher.
 ```ruby
 DBQueryMatchers.configure do |config|
   config.ignores = [/SHOW TABLES LIKE/]
+
+  # the payload argument is described here:
+  # http://edgeguides.rubyonrails.org/active_support_instrumentation.html#sql-active-record
+  config.on_counted_query do |payload|
+    # do something arbitrary with the query
+  end
 end
 ```

--- a/lib/db_query_matchers/configuration.rb
+++ b/lib/db_query_matchers/configuration.rb
@@ -1,10 +1,11 @@
 module DBQueryMatchers
   # Configuration for the DBQueryMatcher module.
   class Configuration
-    attr_accessor :ignores
+    attr_accessor :ignores, :on_counted_query
 
     def initialize
       @ignores = []
+      @on_counted_query = Proc.new { }
     end
   end
 end

--- a/lib/db_query_matchers/configuration.rb
+++ b/lib/db_query_matchers/configuration.rb
@@ -1,11 +1,11 @@
 module DBQueryMatchers
   # Configuration for the DBQueryMatcher module.
   class Configuration
-    attr_accessor :ignores, :on_counted_query
+    attr_accessor :ignores, :on_query_counted
 
     def initialize
       @ignores = []
-      @on_counted_query = Proc.new { }
+      @on_query_counted = Proc.new { }
     end
   end
 end

--- a/lib/db_query_matchers/query_counter.rb
+++ b/lib/db_query_matchers/query_counter.rb
@@ -43,6 +43,7 @@ module DBQueryMatchers
       return if any_match?(DBQueryMatchers.configuration.ignores, payload[:sql])
       @count += 1
       @log << payload[:sql]
+      DBQueryMatchers.configuration.on_counted_query.call(payload)
     end
 
     private

--- a/lib/db_query_matchers/query_counter.rb
+++ b/lib/db_query_matchers/query_counter.rb
@@ -43,7 +43,7 @@ module DBQueryMatchers
       return if any_match?(DBQueryMatchers.configuration.ignores, payload[:sql])
       @count += 1
       @log << payload[:sql]
-      DBQueryMatchers.configuration.on_counted_query.call(payload)
+      DBQueryMatchers.configuration.on_query_counted.call(payload)
     end
 
     private

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -23,6 +23,40 @@ describe '#make_database_queries' do
       end
     end
 
+    context 'when there is an on_counted_query callback configured' do
+      before do
+        @callback_called = false
+
+        DBQueryMatchers.configure do |config|
+          config.on_counted_query = lambda do |payload|
+            @callback_called = true
+          end
+        end
+      end
+
+      after { DBQueryMatchers.reset_configuration }
+
+      it 'is called' do
+        expect { subject }.to make_database_queries
+        expect(@callback_called).to eq(true)
+      end
+
+      context 'with an `ignores` pattern' do
+        before do
+          DBQueryMatchers.configure do |config|
+            config.ignores = ignores
+          end
+        end
+
+        let(:ignores) { [/SELECT.*FROM.*cats/] }
+
+        it 'is not called' do
+          expect { subject }.not_to make_database_queries
+          expect(@callback_called).to eq(false)
+        end
+      end
+    end
+
     context 'when an `ignores` pattern is configured' do
       before do
         DBQueryMatchers.configure do |config|

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -23,12 +23,12 @@ describe '#make_database_queries' do
       end
     end
 
-    context 'when there is an on_counted_query callback configured' do
+    context 'when there is an on_query_counted callback configured' do
       before do
         @callback_called = false
 
         DBQueryMatchers.configure do |config|
-          config.on_counted_query = lambda do |payload|
+          config.on_query_counted = lambda do |payload|
             @callback_called = true
           end
         end


### PR DESCRIPTION
Extensive use of DBQueryMatchers can result in test assertions that are
hard to reason about. For example, the Brigade test suite has multiple
assertions that over 20, 30, or 40 queries are made. That's a lot to
debug if you're making some kind of sweeping change!

In order to provide users with a better time debugging/profiling exactly
which queries are being logged, this adds a configuration option that
accepts a proc to be called whenever a query is logged.

This is the simplest possible implementation. If people find this
useful, we can later support multiple callbacks, or some kind of better
API.