### PR TITLE
The `schemaless` configuration value is added to ignore SCHEMA type queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,13 @@ To exclude certain types of queries from being counted, specify an
 a query matches one of the patterns in this array, it will not be
 counted in the `make_database_queries` matcher.
 
+To exclude SCHEMA queries, add `schemaless` to the configuration. This will
+help avoid failing specs due to ActiveRecord load order.
+
 ```ruby
 DBQueryMatchers.configure do |config|
   config.ignores = [/SHOW TABLES LIKE/]
+  config.schemaless = true
 
   # the payload argument is described here:
   # http://edgeguides.rubyonrails.org/active_support_instrumentation.html#sql-active-record

--- a/lib/db_query_matchers/configuration.rb
+++ b/lib/db_query_matchers/configuration.rb
@@ -1,11 +1,12 @@
 module DBQueryMatchers
   # Configuration for the DBQueryMatcher module.
   class Configuration
-    attr_accessor :ignores, :on_query_counted
+    attr_accessor :ignores, :on_query_counted, :schemaless
 
     def initialize
       @ignores = []
       @on_query_counted = Proc.new { }
+      @schemaless = false
     end
   end
 end

--- a/lib/db_query_matchers/query_counter.rb
+++ b/lib/db_query_matchers/query_counter.rb
@@ -41,6 +41,7 @@ module DBQueryMatchers
     def callback(_name, _start,  _finish, _message_id, payload)
       return if @matches && !any_match?(@matches, payload[:sql])
       return if any_match?(DBQueryMatchers.configuration.ignores, payload[:sql])
+      return if DBQueryMatchers.configuration.schemaless && payload[:name] == "SCHEMA"
       @count += 1
       @log << payload[:sql]
       DBQueryMatchers.configuration.on_query_counted.call(payload)

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -228,6 +228,33 @@ describe '#make_database_queries' do
         end
       end
     end
+
+    context 'when a `schemaless` option is true' do
+      before do
+        DBQueryMatchers.configure do |config|
+          config.schemaless = true
+        end
+      end
+
+      it 'does not count column information queries' do
+        Cat.connection.schema_cache.clear!
+        Cat.reset_column_information
+        expect { subject }.to make_database_queries(count: 1)
+      end
+    end
+
+    context 'when a `schemaless` option is false' do
+      before do
+        DBQueryMatchers.configure do |config|
+          config.schemaless = false
+        end
+      end
+
+      it 'does count column information queries' do
+        Cat.reset_column_information
+        expect { subject }.to make_database_queries(count: 2..4)
+      end
+    end
   end
 
   context 'when no queries are made' do
@@ -252,7 +279,7 @@ describe '#make_database_queries' do
   end
 
   context 'when some other expectation in the block fails' do
-    subject { 
+    subject {
       Cat.first
       raise RSpec::Expectations::ExpectationNotMetError.new('other')
     }


### PR DESCRIPTION
We use db-query-matchers to lock down performance, and it leads to unpredictable meta queries when specs are run individually vs in a group. They aren't able to be corrected via regex because the queries themselves don't identify specifically what they are. However, ActiveRecord sets SCHEMA name in the instrumentation payload.