### PR TITLE
Add an option to display query backtrace.

### DIFF
--- a/lib/db_query_matchers/configuration.rb
+++ b/lib/db_query_matchers/configuration.rb
@@ -1,12 +1,14 @@
 module DBQueryMatchers
   # Configuration for the DBQueryMatcher module.
   class Configuration
-    attr_accessor :ignores, :on_query_counted, :schemaless
+    attr_accessor :ignores, :on_query_counted, :schemaless, :log_backtrace, :backtrace_filter
 
     def initialize
       @ignores = []
       @on_query_counted = Proc.new { }
       @schemaless = false
+      @log_backtrace = false
+      @backtrace_filter = Proc.new { |backtrace| backtrace }
     end
   end
 end

--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -69,8 +69,8 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
 
   failure_message_when_negated do |_|
     <<-EOS
-      expected no queries, but #{@counter.count} were made:
-      #{@counter.log.join("\n")}
+expected no queries, but #{@counter.count} were made:
+#{@counter.log.join("\n")}
     EOS
   end
 

--- a/lib/db_query_matchers/query_counter.rb
+++ b/lib/db_query_matchers/query_counter.rb
@@ -42,8 +42,10 @@ module DBQueryMatchers
       return if @matches && !any_match?(@matches, payload[:sql])
       return if any_match?(DBQueryMatchers.configuration.ignores, payload[:sql])
       return if DBQueryMatchers.configuration.schemaless && payload[:name] == "SCHEMA"
-      @count += 1
-      @log << payload[:sql]
+
+      count_query
+      log_query(payload[:sql])
+
       DBQueryMatchers.configuration.on_query_counted.call(payload)
     end
 
@@ -51,6 +53,22 @@ module DBQueryMatchers
 
     def any_match?(patterns, sql)
       patterns.any? { |pattern| sql =~ pattern }
+    end
+
+    def count_query
+      @count += 1
+    end
+
+    def log_query(sql)
+      log_entry = sql.strip
+
+      if DBQueryMatchers.configuration.log_backtrace
+        raw_backtrace = caller
+        filtered_backtrace = DBQueryMatchers.configuration.backtrace_filter.call(raw_backtrace)
+        log_entry += "\n#{filtered_backtrace.join("\n")}\n"
+      end
+
+      @log << log_entry
     end
   end
 end

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -255,6 +255,26 @@ describe '#make_database_queries' do
         expect { subject }.to make_database_queries(count: 2..4)
       end
     end
+
+    context 'when a `log_backtrace` option is true' do
+      before do
+        DBQueryMatchers.configure do |config|
+          config.log_backtrace = true
+          config.backtrace_filter = Proc.new do |backtrace|
+            backtrace.select { |line| line.start_with?(__FILE__) } # only show lines in this file
+          end
+        end
+      end
+
+      it 'logs the backtrace for the query' do
+        expect do
+          expect { subject }.not_to make_database_queries
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError) do |e|
+          expect(e.message).to match(/SELECT/)
+          expect(e.message).to include(__FILE__)
+        end
+      end
+    end
   end
 
   context 'when no queries are made' do


### PR DESCRIPTION
Usage:

    DBQueryMatchers.configure do |config|
      config.log_backtrace = true
    end

One can also filter the backtrace to display only relevant lines:

    DBQueryMatchers.configure do |config|
      config.log_backtrace = true
      config.backtrace_filter = Proc.new do |backtrace|
        backtrace.select { |line| line.start_with?(Rails.root.to_s) }
      end
    end

Example output:

       expected no queries, but 1 were made:
       SELECT  "things".* FROM "things"  ORDER BY "things"."id" ASC LIMIT 1
       /myapp/app/models/thing.rb:5:in `get_one'
       /myapp/app/helpers/application_helper.rb:270:in `first_thing'