### PR TITLE
Add support for alternative ORMs

### DIFF
--- a/lib/db_query_matchers.rb
+++ b/lib/db_query_matchers.rb
@@ -3,7 +3,6 @@ require 'db_query_matchers/make_database_queries'
 require 'db_query_matchers/query_counter'
 require 'db_query_matchers/configuration'
 require 'active_support'
-require 'active_record'
 
 # Main module that holds global configuration.
 module DBQueryMatchers

--- a/lib/db_query_matchers/configuration.rb
+++ b/lib/db_query_matchers/configuration.rb
@@ -1,9 +1,10 @@
 module DBQueryMatchers
   # Configuration for the DBQueryMatcher module.
   class Configuration
-    attr_accessor :ignores, :on_query_counted, :schemaless, :log_backtrace, :backtrace_filter
+    attr_accessor :ignores, :on_query_counted, :schemaless, :log_backtrace, :backtrace_filter, :db_event
 
     def initialize
+      @db_event = "sql.active_record"
       @ignores = []
       @on_query_counted = Proc.new { }
       @schemaless = false

--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -58,7 +58,7 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
     end
     @counter = DBQueryMatchers::QueryCounter.new(counter_options)
     ActiveSupport::Notifications.subscribed(@counter.to_proc,
-                                            'sql.active_record',
+                                            DBQueryMatchers.configuration.db_event,
                                             &block)
     if absolute_count = options[:count]
       absolute_count === @counter.count

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -275,6 +275,26 @@ describe '#make_database_queries' do
         end
       end
     end
+
+    context 'when a different db_event is configured' do
+      before do
+        DBQueryMatchers.configure do |config|
+          config.db_event = 'other_event'
+        end
+      end
+
+      after { DBQueryMatchers.reset_configuration }
+
+      it 'does not respond to normal events' do
+        expect { subject }.not_to make_database_queries
+      end
+
+      it 'responds to custom event' do
+        expect {
+          ActiveSupport::Notifications.publish 'other_event', Time.now, Time.now, 1, { sql: "FOO" }
+        }.to make_database_queries(count: 1)
+      end
+    end
   end
 
   context 'when no queries are made' do
@@ -310,4 +330,5 @@ describe '#make_database_queries' do
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /other/)
     end
   end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'db_query_matchers'
+require 'active_record'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 


### PR DESCRIPTION
At Quipper we use MongoMapper, which does not run on ActiveRecord.

Your very nice gem can be connected to it, to count queries when collections are fetched, but to work properly it needs a bit of tweaking to remove the `active_record` dependency, and allow alternative events (for safety) to be listened to.