### PR TITLE
Allow support for spec suites using mocking frameworks other than RSpec Mocks

### DIFF
--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -1,6 +1,5 @@
 require 'rspec/core'
 require 'rspec/expectations'
-require 'rspec/mocks'
 
 # Custom matcher to check for database queries performed by a block of code.
 #


### PR DESCRIPTION
Right now the matcher file has a hardcoded `require` statement for RSpec Mocks (added in https://github.com/brigade/db-query-matchers/pull/2).  This line is causing errors for us, because we use [RR](https://github.com/rr/rr) in our specs rather than RSpec Mocks.  Anybody using any of the other [mocking frameworks](https://www.relishapp.com/rspec/rspec-core/v/3-5/docs/mock-framework-integration) (e.g. Mocha, FlexMock) is probably also going to run into similar issues.

It doesn't look like there's anywhere in the gem where RSpec Mocks is used, and the tests all seem to pass with the require statement removed.  

PS: _great_ gem.  Love it!